### PR TITLE
feature/support transit encoded inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "floki",
   "description": "A JSON/EDN browser for the terminal",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "author": "Denis Isidoro",
   "repository": "https://github.com/denisidoro/floki.git",
   "license": "Apache 2.0",

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
             :distribution :repo}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/clojurescript "1.10.439"]
+                 [com.cognitect/transit-cljs "0.8.256"]
                  [reagent "0.8.1" :exclusions [[cljsjs/react]
                                                [cljsjs/react-dom]
                                                [cljsjs/create-react-class]]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject floki "0.6.5-SNAPSHOT"
+(defproject floki "0.6.6-SNAPSHOT"
   :description "An EDN/JSON browser for the terminal"
   :url "https://github.com/denisidoro/floki"
   :min-lein-version "2.7.1"

--- a/src/common/stdin.cljs
+++ b/src/common/stdin.cljs
@@ -16,5 +16,5 @@
   (.on stdin "end"
        (fn []
          ; (print "END EVENT!!!!")
-         (swap! stdinput #(->> % count dec (subs % 0)))
+         (swap! stdinput #(.trim %))
          (callback @stdinput))))

--- a/src/common/stdin.cljs
+++ b/src/common/stdin.cljs
@@ -1,5 +1,6 @@
 (ns common.stdin
-  (:require [process :as process]))
+  (:require [process :as process]
+            [clojure.string :as str]))
 
 (def stdinput (atom ""))
 (def stdin (.-stdin process))
@@ -16,5 +17,5 @@
   (.on stdin "end"
        (fn []
          ; (print "END EVENT!!!!")
-         (swap! stdinput #(.trim %))
+         (swap! stdinput #(str/trim %))
          (callback @stdinput))))


### PR DESCRIPTION
Fixes #46 

Think it probably fixes #42 too, as looked like you were assuming there was a carriage return always...?  see what you think.

For reference: [MDN: String.prototype.trim](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim)

