### PR TITLE
Bug/fix parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ package-lock.json
 yarn.lock
 /bin
 package.bkp.json
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "floki",
   "description": "A JSON/EDN browser for the terminal",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "Denis Isidoro",
   "repository": "https://github.com/denisidoro/floki.git",
   "license": "Apache 2.0",

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject floki "0.7.0-SNAPSHOT"
+(defproject floki "0.7.1-SNAPSHOT"
   :description "An EDN/JSON browser for the terminal"
   :url "https://github.com/denisidoro/floki"
   :min-lein-version "2.7.1"

--- a/src/floki/core.cljs
+++ b/src/floki/core.cljs
@@ -32,24 +32,20 @@
 
 (defn convert
   [x]
-  (let [res (try
-              {:format :json
-               :data   (json->edn x)}
+  (let [tr (transit/reader :json)
+        res (try
+              {:format :edn
+               :data   (transit/read tr x)}
               (catch js/Error e0
                 (try
                   {:format :edn
                    :data   (conversion/edn-str->edn x)}
                   (catch js/Error e1
                     (try
-                      (let [tr (transit/reader :json)]
-                        {:format :edn
-                         :data   (transit/read tr x)})
+                      {:format :json
+                       :data   (json->edn x)}
                       (catch js/Error e2
-                        (try
-                          {:format :json
-                           :data   (json->edn (str x "}"))}
-                          (catch js/Error e3
-                            (error-input e0 e1 e2 e3 x)))))))))]
+                        (error-input e0 e1 e2 x)))))))]
 
     (if (seq res)
       res


### PR DESCRIPTION
JSON parsing should only be attempted once transit parsing has failed, as transit is encoded as valid JSON. Attempting to parse as JSON first will always select that route regardless of transityness of the input data. 

The test steps below should really be added as a test suite of some sort, but they should demonstrate that the parsing is happening correctly. 

### To test

- check out branch
- perform prod build with `lein cljsbuild once prod`
- run `echo '#{1 2 3}' | node target/main.js` and observe an EDN set is visible
- run `echo '{:foo :bar}' | node target/main.js` and observe an EDN map is visible
- run `echo '{"hi": "there"}' | node target/main.js` and observe a JSON map is visible
- run `echo '["^ ","~:score",1]' | node target/main.js` and observe the transit encoded EDN map is visible.
